### PR TITLE
[FG-42] 뿌리오 메세지 전송 API 연동 완료

### DIFF
--- a/app/address/modal/select-contact-modal.tsx
+++ b/app/address/modal/select-contact-modal.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import AddressBook from '../address-book'
 import { Contact2 } from '../entity'
+import { api } from './service'
 
 export type Target = {
   to: string,
@@ -58,8 +59,21 @@ export default function AddressBookModal() {
     })
   }
 
+  // ※ 임시코드!!!! 모달 적용하는 사람은 해당 정보 삭제할 것
+  const [inputValue, setInputValue] = useState("");
+
   return (
     <div className="p-8">
+      {/* ※ 임시코드!!!! 모달 적용하는 사람은 해당 정보 삭제할 것 */}
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        placeholder="전송하는 사람의 전화번호"
+        className="border border-gray-300 rounded-lg p-2 w-80 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+
+
       {/* Trigger Button */}
       <Button
         className="bg-blue-500 hover:bg-blue-600 text-white rounded-lg shadow-sm transition-colors duration-300"
@@ -104,6 +118,39 @@ export default function AddressBookModal() {
                   name: contact.name
                 }));
                 console.log('Sending:', targets);
+
+                // TODO: API 구체화
+                // 1. messageType 설정하기 (조건문으로 구분가능 (1) 길이 (2) 이미지 파일 유무)
+                const messageType = "SMS" // SMS, MMS, LMS 존재
+
+                // 2. 전송 전화번호 설정 (유저에 본인 전화번호 있을 줄 알았는데, 없음)
+                // const fromNumber = "01000000000"
+                const fromNumber = inputValue
+
+                // 3. 제목 전송 받기
+                const subject = "전송할 제목입니다." // LMS와 MMS에만 필요
+                
+                // 4. 본문 전송 받기
+                // ※ 본문 길이 예외처리 할 것
+                const content = "안녕하세요 테스트중입니다."
+
+                // 5. 파일 바이너리 데이터 전송 받기, 파일 이름은 DateTime으로 할 듯
+                // ※ 파일 길이 예외처리 할 것
+                const fileData = "" // 파일 바이너리 데이터
+
+                api.sendMessage({
+                  "messageType": messageType,
+                  "content": content,
+                  "fromNumber": fromNumber,
+                  "targets": targets,
+                  "subject": subject,
+                  "files": {
+                    "name": `image_${new Date().toLocaleDateString()}`,
+                    "size": fileData.length,
+                    "data": fileData
+                  }
+                })
+
                 handleClose();
               }}
               className="bg-blue-500 hover:bg-blue-600 text-white"

--- a/app/address/modal/service.tsx
+++ b/app/address/modal/service.tsx
@@ -1,0 +1,62 @@
+import apiClient from "@/services/apiClient";
+
+type PpurioMessageDTO = {
+    messageType: string;
+    content: string;
+    fromNumber: string;
+    targets: Target[];
+    subject: string;
+    files: Files;
+};
+
+type Target = {
+    to: string;
+    name: string;
+    changeWord: ChangeWord;
+};
+
+type ChangeWord = {
+    var1: string;
+    var2: string;
+    var3: string;
+    var4: string;
+    var5: string;
+    var6: string;
+    var7: string;
+};
+
+type Files = {
+    name: String;
+    size: Number;
+    data: String;
+};
+
+type PpurioMessageResponse = {
+    code: String;
+    description: String;
+    refKey: String;
+    messageKey: String;
+};
+
+export interface CommonResponse<T> {
+    code: number;
+    message: string;
+    data: T;
+  }
+
+export const api = {
+    sendMessage: async (
+        PpurioMessageDTO : PpurioMessageDTO
+    ): Promise<PpurioMessageResponse|undefined> => {
+        try {
+            const response = await apiClient.post<CommonResponse<PpurioMessageResponse>>(`/ppurio/message`, PpurioMessageDTO)
+
+            const newFolder2 = response.data.data;
+            if(response.data.code == 200) return newFolder2
+    
+            return undefined;
+        } catch(error) {
+            return undefined
+        }
+    },
+}


### PR DESCRIPTION
# :: 작업 주제
*FG-42* : 뿌리오 메세지 전송 API 연동 완료

# :: 구현사항 설명
1. `Component` 접근 후에 바로 메세지가 전송되도록 API 추가
2. `fiveguys-backend`에 파일 데이터를 바이너리로 받는 REST API 추가 개설 완료

# :: 보완할점
1. 테스트를 위해 `select-contact-modal.tsx`에 `input` 태그 추가해 두었음. 실 사용자는 삭제 처리 할 것
3. 추후 매개변수를 늘려서 속성을 전달할 예정